### PR TITLE
アカウント編集画面にうつるボタン作成、編集画面にコメント記入欄設置

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,10 @@
 class ApplicationController < ActionController::Base
-    before_action :configure_permitted_parameters, if: :devise_controller? 
+  before_action :configure_permitted_parameters, if: :devise_controller? 
 
   private
 
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up,keys:[:email]) # 注目
+      devise_parameter_sanitizer.permit(:sign_up,keys:[:email, :self_introduction]) # 注目
     end
     
     end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -18,6 +18,12 @@
   <% end %>
 
   <div class="field">
+    <%= f.label :self_introduction, "コメント" %><br />
+    <%= f.text_field :self_introduction, autofocus: true, autocomplete: "self_introduction" %>
+  </div>
+
+
+  <div class="field">
     <%= f.label :password, "パスワード変更" %> <i>(変更したい場合)</i><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,5 @@
 <h1>タスク一覧ページ</h1>
-  
+    <%= link_to "アカウント編集", edit_user_registration_path %></br>
     <% @tasks.each do |task| %>
       <iframe
           src="https://www.youtube.com/embed/<%= task.url.last(11)%>" <!-- URl末尾のvideo_idの取得 -->


### PR DESCRIPTION
※質問を含みます。

タスク一覧画面から、アカウント編集画面にうつるようにしました。
アカウント編集画面にコメントの編集箇所を追加しました。

【質問】
コントローラーで:emailと:self_introdoctionのカラムを許可したつもりなのですが、動かしてみると、その２つのカラムは通りませんでした。