### PR TITLE
公開設定フォルダにある全タスクを表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "tzinfo-data"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
-gem "bootstrap"
+# gem "bootstrap"
 gem "devise"
 
 # Use Sass to process CSS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,16 +68,10 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    autoprefixer-rails (10.4.7.0)
-      execjs (~> 2)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
-    bootstrap (5.2.2)
-      autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.11.6, < 3)
-      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     capybara (3.37.1)
       addressable
@@ -101,8 +95,6 @@ GEM
       responders
       warden (~> 1.2.3)
     erubi (1.11.0)
-    execjs (2.8.1)
-    ffi (1.15.5-x64-mingw-ucrt)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -139,7 +131,6 @@ GEM
     nokogiri (1.13.9-x64-mingw-ucrt)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    popper_js (2.11.6)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -182,14 +173,6 @@ GEM
       railties (>= 5.0)
     rexml (3.2.5)
     rubyzip (2.3.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -206,7 +189,6 @@ GEM
     stimulus-rails (1.1.1)
       railties (>= 6.0.0)
     thor (1.2.1)
-    tilt (2.0.11)
     timeout (0.3.0)
     turbo-rails (1.3.2)
       actionpack (>= 6.0.0)
@@ -240,7 +222,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  bootstrap
   capybara
   debug
   devise

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    open = Folder.select(:id).where(status:0)
+    @tasks = Task.where(folder_id:open)
   end
 
   def create


### PR DESCRIPTION
指摘のあった箇所です。
公開設定フォルダの中のタスクのみを表示するようにしました。
bootstrapを切ったのは、エラーを解消できなかったからです。
mini_racerを入れろと書いてある気がしたので、入れてみたのですが、直らなかったです。
エラーのスクショはslackに貼っておきます。