### PR TITLE
rails db:migration時にrenameするカラムがないと怒られてエラーになるので修正

### DIFF
--- a/db/migrate/20211127235041_devise_create_users.rb
+++ b/db/migrate/20211127235041_devise_create_users.rb
@@ -13,7 +13,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[7.0]
 
       ## Rememberable
       t.datetime :remember_created_at
-
       ## Trackable
       # t.integer  :sign_in_count, default: 0, null: false
       # t.datetime :current_sign_in_at
@@ -33,7 +32,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[7.0]
       # t.datetime :locked_at
 
       t.string :name
-      t.text :self_introduction
       t.timestamps null: false
     end
 

--- a/db/migrate/20221126032156_add_comment_to_users.rb
+++ b/db/migrate/20221126032156_add_comment_to_users.rb
@@ -1,0 +1,5 @@
+class AddCommentToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :self_introduction, :string
+  end
+end

--- a/db/migrate/20221126032156_rename_comment_column_to_users.rb
+++ b/db/migrate/20221126032156_rename_comment_column_to_users.rb
@@ -1,5 +1,0 @@
-class RenameCommentColumnToUsers < ActiveRecord::Migration[7.0]
-  def change
-    rename_column :users, :comment, :self_introduction
-  end
-end

--- a/db/migrate/20221126033042_add_column_folders.rb
+++ b/db/migrate/20221126033042_add_column_folders.rb
@@ -1,5 +1,0 @@
-class AddColumnFolders < ActiveRecord::Migration[7.0]
-  def up
-    add_column :folders, :user_id, :integer, comment: "ユーザー名"
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_27_235041) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_26_071214) do
   create_table "folders", force: :cascade do |t|
     t.string "folder_name", null: false
     t.integer "status", null: false
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
   end
 
   create_table "followers", force: :cascade do |t|
@@ -34,9 +34,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_27_235041) do
   end
 
   create_table "tasks", force: :cascade do |t|
+    t.integer "user_id"
     t.string "url", null: false
     t.text "description", null: false
-    t.integer "user_id"
     t.integer "folder_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -49,9 +49,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_27_235041) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "name"
-    t.text "self_introduction"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "self_introduction"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
やったこと
- devise_create_usersテーブルで作成する際に`self_introduction`カラムが追加されないため削除
  - self_introductionは、add_columnで別対応にしている
- `db/migrate/20221126032156_rename_comment_column_to_users.rb`同じことを書いているためいらない
- db/migrate/20221126033042_add_column_folders.rbなくても追加されるので削除