### PR TITLE
タスク詳細画面における、URLとメモのコピー（js使用）

### DIFF
--- a/app/assets/javascripts/copy.js
+++ b/app/assets/javascripts/copy.js
@@ -1,0 +1,12 @@
+function copyToClipboard(){
+  var info = [document.getElementById('task_url').value,
+            document.getElementById("task_description").value];
+
+  navigator.clipboard.writeText(info).then(
+  () => {
+    alert('メモとURLをコピーしました。');
+  },
+  () => {
+    alert('コピーに失敗しました。');
+  });
+}

--- a/app/views/my_tasks/edit.html.erb
+++ b/app/views/my_tasks/edit.html.erb
@@ -14,3 +14,5 @@
           #ここにフォルダ選択プルタブを作りたい  
 <% end %>
 <%= link_to '戻る', my_tasks_path %>
+<input type="button" value="コピー" onclick="copyToClipboard()">
+<%= javascript_tag 'copy' %>


### PR DESCRIPTION
スプレッドシートNo14「非同期通信を使い、タスクをurlと文章に変えて、チャットへ送ることができる」に対するPRです。

もともとは、タスク一覧画面から行う予定でしたが、詳細画面からできたほうがいいなと思ったので、詳細画面で実装しました。